### PR TITLE
Change the target JDK to 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'signing'
 version = "1.2.3-SNAPSHOT"
 group = "nl.javadude.assumeng"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.5
+targetCompatibility = 1.5
 
 
 repositories {


### PR DESCRIPTION
This PR addresses the situation in which AssumeNG is used in a build targeting JDK 1.5.
