### PR TITLE
Allow boolean test methods to be static methods from other classes.

### DIFF
--- a/src/main/java/nl/javadude/assumeng/Assumption.java
+++ b/src/main/java/nl/javadude/assumeng/Assumption.java
@@ -22,5 +22,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 public @interface Assumption {
+    static final class TestClass {};
+
     String[] methods();
+    Class<?> methodClass() default TestClass.class;
 }

--- a/src/test/java/nl/javadude/assumeng/AssumptionTest.java
+++ b/src/test/java/nl/javadude/assumeng/AssumptionTest.java
@@ -25,14 +25,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.testng.Assert.fail;
 
+class InverseLogic {
+    public static boolean alwaysFalse() {
+        return true;
+    }
+
+    public static boolean alwaysTrue() {
+        return false;
+    }
+}
+
 @Listeners(value = {AssumptionListener.class, AssumptionChecker.class})
 public class AssumptionTest {
 
     @AfterClass
     public void assumptionsShouldBeCorrect() {
-        assertThat(AssumptionChecker.getSkippedTests(), equalTo(3));
+        assertThat(AssumptionChecker.getSkippedTests(), equalTo(4));
         assertThat(AssumptionChecker.getFailedTests(), equalTo(0));
-        assertThat(AssumptionChecker.getSuccessTests(), equalTo(2));
+        assertThat(AssumptionChecker.getSuccessTests(), equalTo(3));
     }
 
     @Test
@@ -51,6 +61,18 @@ public class AssumptionTest {
     @Assumption(methods = {"alwaysTrue", "alwaysFalse"})
     public void shouldAlsoSkip() {
         fail("Should not run");
+    }
+
+    @Test
+    @Assumption(methods = "alwaysTrue", methodClass = InverseLogic.class)
+    public void shouldSkipInverse() {
+        fail("Should not run");
+    }
+
+    @Test
+    @Assumption(methods = "alwaysFalse", methodClass = InverseLogic.class)
+    public void shouldSucceedInverse() {
+        assertThat(InverseLogic.alwaysFalse(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
I was hoping to use boolean tests from static utility classes I have, to avoid having to figure out how to get all the relevant test classes to extend the one that has the boolean methods I want (no multiple inheritance). Maybe this'll help others too.
